### PR TITLE
Fix for IRI 1.4.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM iotaledger/iri:v1.4.1.4 as base
+FROM iotaledger/iri:v1.4.1.6 as base
 
 FROM openjdk:8-jre-slim
 


### PR DESCRIPTION
Raised IRI version to 1.4.1.6
There is also a new Docker tag: dev
Maybe this can used in the future instead of pinning the version.